### PR TITLE
Add support for dynamically loaded images and strictlybetter.eu

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -28,7 +28,8 @@
 				"https://scryfall.com/*",
 				"https://gatherer.wizards.com/*",
 				"https://edhrec.com/*",
-				"https://www.magicspoiler.com/*"
+				"https://www.magicspoiler.com/*",
+				"https://www.strictlybetter.eu/*"
 			],
 			"js": ["contentscripts/main.js"],
 			"css": ["styles.css"]

--- a/styles.css
+++ b/styles.css
@@ -9,6 +9,7 @@
 	border-radius: 30px;
 	width: 30px;
 	height: 30px;
+	z-index: 99999;
 }
 .dl-plus-hori {
 	position: absolute;


### PR DESCRIPTION
Add support for dynamically loaded images and [https://www.strictlybetter.eu](https://www.strictlybetter.eu)

DOM edits are monitored by MutationObserver class. 
hostMap in main.js has a new attribute 'observer', which is a selector to find DOM nodes that should be monitored for dynamic changes, so decklist buttons can be added to new content. If no 'observer' attribute exists for the host, no DOM change monitoring is done.

